### PR TITLE
Fix git host key verification on vercel

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8221,7 +8221,7 @@ react-is@^18.0.0:
 
 "react-rough-notation@git+https://github.com/turahe/react-rough-notation.git":
   version "1.0.5"
-  resolved "git+ssh://git@github.com/turahe/react-rough-notation.git#123850aed55d040e6813d457e335f6485ba89e52"
+  resolved "https://github.com/turahe/react-rough-notation.git#123850aed55d040e6813d457e335f6485ba89e52"
   dependencies:
     rough-notation "^0.5.1"
 


### PR DESCRIPTION
Update `react-rough-notation` dependency in `yarn.lock` to use HTTPS instead of SSH to resolve Vercel build failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0c67f60-fe94-4fd4-848f-b5a90d86a42b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0c67f60-fe94-4fd4-848f-b5a90d86a42b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

